### PR TITLE
Add a RFC-7807 json rejection

### DIFF
--- a/examples/axum/Cargo.lock
+++ b/examples/axum/Cargo.lock
@@ -42,6 +42,7 @@ checksum = "810a80b128d70e6ed2bdf3fe8ed72c0ae56f5f5948d01c2753282dd92a84fce8"
 dependencies = [
  "async-trait",
  "axum-core",
+ "axum-macros",
  "bytes",
  "futures-util",
  "http",
@@ -85,6 +86,18 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00c055ee2d014ae5981ce1016374e8213682aa14d9bf40e48ab48b5f3ef20eaa"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -227,6 +240,12 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"

--- a/examples/axum/Cargo.toml
+++ b/examples/axum/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 problemdetails = { path = "../..", features = ["axum"] }
 
-axum = { version = "0.7.1" }
+axum = { version = "0.7.1", features = ["macros"] }
 http = "1.0.0"
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = { version = "1.0.108", features = ["preserve_order"] }

--- a/examples/axum/src/main.rs
+++ b/examples/axum/src/main.rs
@@ -1,8 +1,17 @@
 use std::net::SocketAddr;
 
-use axum::{routing::get, Router};
+use axum::{
+    extract::{
+        rejection::{self, BytesRejection, JsonRejection},
+        FromRequest,
+    },
+    response::IntoResponse,
+    routing::{get, post},
+    Router,
+};
 use http::StatusCode;
-use problemdetails::axum::PanicHandlerBuilder;
+use problemdetails::{axum::PanicHandlerBuilder, Problem};
+use serde::Deserialize;
 
 #[tokio::main]
 async fn main() {
@@ -10,7 +19,8 @@ async fn main() {
     let app = Router::new()
         .route("/", get(notimplemented))
         .route("/forbidden", get(forbidden))
-        .route("/panic", get(panic));
+        .route("/panic", get(panic))
+        .route("/json", post(json));
 
     // add a panic handler if you want one
     let app = app.layer(
@@ -42,4 +52,56 @@ async fn forbidden() -> Result<String, problemdetails::Problem> {
 
 async fn panic() {
     panic!("Oh no!");
+}
+
+// example how to handle JSON rejection and return a problemdetail
+
+// some example JSON deserializable data
+#[derive(Debug, Deserialize)]
+struct ExampleData {
+    name: String,
+}
+
+// an example handler with our special MyJson extractor
+async fn json(MyJson(data): MyJson<ExampleData>) {
+    println!("{:?}", data);
+    println!("{}", data.name);
+}
+
+pub struct MyRejection(Problem);
+
+#[derive(FromRequest)]
+#[from_request(via(axum::Json), rejection(MyRejection))]
+pub struct MyJson<T>(pub T);
+
+impl IntoResponse for MyRejection {
+    fn into_response(self) -> axum::response::Response {
+        return self.0.into_response();
+    }
+}
+
+impl From<JsonRejection> for MyRejection {
+    fn from(rejection: rejection::JsonRejection) -> Self {
+        let (status, body, title) = match rejection {
+            JsonRejection::JsonDataError(err) => {
+                (err.status(), err.body_text(), "JSON deserialization error")
+            },
+            JsonRejection::JsonSyntaxError(err) => {
+                (err.status(), err.body_text(), "JSON syntax error")
+            },
+            JsonRejection::MissingJsonContentType(err) => {
+                (err.status(), err.body_text(), "Content type error")
+            },
+            JsonRejection::BytesRejection(BytesRejection::FailedToBufferBody(err)) => {
+                (err.status(), err.body_text(), "Request buffering error")
+            },
+            _ => (StatusCode::BAD_GATEWAY, "".to_string(), "Unknown error"),
+        };
+
+        MyRejection(
+            problemdetails::new(status)
+                .with_title(body)
+                .with_detail(title),
+        )
+    }
 }


### PR DESCRIPTION
This PR implements RFC-7807 json rejections.

Some points that require discussion or further work:
- [x] Maybe this should not be a part of the library, but instead just an example. The main issue is there's no way to configure different titles for the rejection. Maybe adding it as an example to the examples folder would be more beneficial for the end users of the library?
- [x] I'm not sure if using macros to generate the implementation is the best course of action. A hand-made implementation would not require the `macros` feature in axum.
- [x] There are no tests, but I'd prefer to get your input on the previous issues first, @sazzer, before implementing them.

Closes #6.