### PR TITLE
Update tower-http version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "problemdetails"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 license = "MIT"
 description = "Support for Problem Details (RFC-7807 / RFC-9457) responses in HTTP APIs"
@@ -12,7 +12,7 @@ categories = ["web-programming::http-server", "api-bindings"]
 
 [dependencies]
 axum = { version = "0.7.4", optional = true }
-tower-http = { version = "0.5.1", features = ["catch-panic"], optional = true }
+tower-http = { version = "0.6.1", features = ["catch-panic"], optional = true }
 http = "1.0.0"
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = { version = "1.0.113", features = ["preserve_order"] }


### PR DESCRIPTION
:wave: Just a quick patch. The latest tower-http has some breaking changes. They don't affect the panic methods but using tower-http 0.6 alongside problemdetails 0.4.1 yields version conflicts.