### PR TITLE
Fix link description in Poem crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //!
 //! Currently supported features are:
 //! * `axum` - For the [Axum](https://crates.io/crates/axum) HTTP Server.
-//! * `poem` - For the [Axum](https://crates.io/crates/poem) HTTP Server.
+//! * `poem` - For the [Poem](https://crates.io/crates/poem) HTTP Server.
 
 #[cfg(feature = "axum")]
 pub mod axum;


### PR DESCRIPTION
Thanks for this crate!  I'm happily using it on my first public Rust API.

Noticed what looks like a copy-paste error while I was adapting it for an internal variant of the RFC.