### PR TITLE
Fixes to some compile errors

### DIFF
--- a/src/axum.rs
+++ b/src/axum.rs
@@ -7,6 +7,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use http::HeaderValue;
 use tower_http::catch_panic::{CatchPanicLayer, ResponseForPanic};
 
 use super::Problem;
@@ -115,7 +116,11 @@ mod tests {
         let router = axum::Router::new()
             .route(
                 "/panic",
-                axum::routing::get(|| async { panic!("Panic message") }),
+                axum::routing::get(|| async {
+                    panic!("Panic message");
+                    #[allow(unreachable_code)]
+                    ()
+                }),
             )
             .layer(crate::axum::PanicHandlerBuilder::new().build());
 
@@ -140,7 +145,11 @@ mod tests {
         let router = axum::Router::new()
             .route(
                 "/panic",
-                axum::routing::get(|| async { panic!("Panic message") }),
+                axum::routing::get(|| async {
+                    panic!("Panic message");
+                    #[allow(unreachable_code)]
+                    ()
+                }),
             )
             .layer(
                 crate::axum::PanicHandlerBuilder::new()
@@ -168,7 +177,11 @@ mod tests {
         let router = axum::Router::new()
             .route(
                 "/panic",
-                axum::routing::get(|| async { panic!("Panic message") }),
+                axum::routing::get(|| async {
+                    panic!("Panic message");
+                    #[allow(unreachable_code)]
+                    ()
+                }),
             )
             .layer(
                 crate::axum::PanicHandlerBuilder::new()


### PR DESCRIPTION
This PR is for fixing some compilation errors I was getting on the latest commit:

- Missing a use statement for HeaderValue.

- Error for testing the panic handlers, issue with 2024 [never type fallback change](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html): if I understand correctly panic! used to fallback to '()' which implements IntoResponse but after the change it falls back to '!' which doesn't and that was causing the error.